### PR TITLE
Fix/performance speed

### DIFF
--- a/chroniclepy/chroniclepy/preprocessing.py
+++ b/chroniclepy/chroniclepy/preprocessing.py
@@ -144,8 +144,7 @@ def extract_usage(dataframe,precision=3600):
     latest_unbackgrounded = False
 
     for idx, row in rawdata.iterrows():
-        tot.append(time.clock() - start_time)
-        start_time = time.clock()
+        
         interaction = row[columns.raw_record_type]
         app = row[columns.full_name]
 

--- a/chroniclepy/chroniclepy/preprocessing.py
+++ b/chroniclepy/chroniclepy/preprocessing.py
@@ -4,6 +4,7 @@ from pytz import timezone
 import pandas as pd
 import numpy as np
 import os
+import time
 
 from .constants import interactions, columns
 from . import utils
@@ -23,7 +24,9 @@ def clean_data(thisdata):
     - extracts datetime information and rounds to 10ms
     - sorts events from the same 10ms by (1) foreground, (2) background
     '''
-
+    start_time = time.clock()
+    print(len(thisdata))
+    utils.logger("Cleaning data", level = 1)
     thisdata = thisdata.dropna(subset=[columns.raw_record_type, columns.raw_date_logged])
     if len(thisdata)==0:
         return(thisdata)
@@ -40,6 +43,8 @@ def clean_data(thisdata):
     thisdata['dt_logged'] = thisdata.apply(utils.get_dt,axis=1)
     thisdata['action'] = thisdata.apply(utils.get_action,axis=1)
     thisdata = thisdata.sort_values(by=['dt_logged', 'action']).reset_index(drop=True)
+
+    print("took", time.clock() - start_time)
     return thisdata.drop(['action'],axis=1)
 
 def get_timestamps(curtime, prevtime=False, row=None, precision=60):
@@ -53,9 +58,6 @@ def get_timestamps(curtime, prevtime=False, row=None, precision=60):
         outtime = [{
             columns.prep_datetime_start: starttime,
             columns.prep_datetime_end: np.NaN,
-            "date": starttime.strftime("%Y-%m-%d"),
-            "starttime": starttime.strftime("%H:%M:%S.%f"),
-            "endtime": np.NaN,
             columns.prep_duration_seconds: np.NaN,
             columns.prep_record_type: np.NaN,
             "participant_id": row['person'],
@@ -86,15 +88,6 @@ def get_timestamps(curtime, prevtime=False, row=None, precision=60):
         outmetrics = {
             columns.prep_datetime_start: starttime,
             columns.prep_datetime_end: endtime,
-            "date": starttime.strftime("%Y-%m-%d"),
-            "starttime": starttime.strftime("%H:%M:%S.%f"),
-            "endtime": endtime.strftime("%H:%M:%S.%f"),
-            "day": (starttime.weekday()+1)%7+1,
-            "weekdayMF": 1 if starttime.weekday() < 5 else 0,
-            "weekdayMTh": 1 if starttime.weekday() < 4 else 0,
-            "weekdaySTh": 1 if (starttime.weekday() < 4 or starttime.weekday()==6) else 0,
-            "hour": starttime.hour,
-            "quarter": int(np.floor(starttime.minute/15.))+1,
             columns.prep_duration_seconds: np.round((endtime - starttime).total_seconds())
         }
 
@@ -115,29 +108,28 @@ def extract_usage(dataframe,precision=3600):
     cols = ['participant_id',
             columns.full_name,
             columns.title,
-            'date',
             columns.prep_datetime_start,
             columns.prep_datetime_end,
-            'starttime',
-            'endtime',
-            'day',  # note: starts on Sunday !
-            'weekdayMF',
-            'weekdayMTh',
-            'weekdaySTh',
-            'hour',
-            'quarter',
             columns.prep_duration_seconds,
             columns.prep_record_type]
 
-    alldata = pd.DataFrame()
+    other_interactions = {
+        interactions.screen_non_interactive : "Screen Non-interactive",
+        interactions.screen_interactive: "Screen Interactive",
+        interactions.notification_seen: "Notification Seen",
+        interactions.notification_interruption: "Notification Interruption"
+    }
+
+    alldata = []
     rawdata = clean_data(dataframe)
     openapps = {}
     latest_unbackgrounded = False
-
-    steps = int(len(rawdata)/50)
+    start_time = time.clock()
+    tot = []
 
     for idx, row in rawdata.iterrows():
-
+        tot.append(time.clock() - start_time)
+        start_time = time.clock()
         interaction = row[columns.raw_record_type]
         app = row[columns.full_name]
 
@@ -149,6 +141,8 @@ def extract_usage(dataframe,precision=3600):
             openapps[app] = {"open" : True,
                              "time": curtime}
 
+            # iterate through older apps
+            # if the app isn't the old app, then it's no longer opened, so "close" all of the other apps
             for olderapp, appdata in openapps.items():
                 
                 if app == olderapp:
@@ -163,6 +157,7 @@ def extract_usage(dataframe,precision=3600):
 
                     openapps[olderapp]['open'] = False
 
+        # if it's an app in the background
         if interaction == interactions.background:
 
             if latest_unbackgrounded and app == latest_unbackgrounded['unbgd_app']:
@@ -174,7 +169,7 @@ def extract_usage(dataframe,precision=3600):
 
                     timepoints[columns.prep_record_type] = 'App Usage'
 
-                    alldata = pd.concat([alldata,timepoints], sort=False)
+                    alldata.append(timepoints)
 
                     openapps[app]['open'] = False
 
@@ -193,7 +188,7 @@ def extract_usage(dataframe,precision=3600):
 
                 timepoints[columns.prep_record_type] = 'App Usage'
 
-                alldata = pd.concat([alldata,timepoints], sort=False)
+                alldata.append(timepoints)
                 
                 openapps[app]['open'] = False
 
@@ -214,34 +209,20 @@ def extract_usage(dataframe,precision=3600):
                     
                     timepoints[columns.prep_record_type] = 'Power Off'
 
-                    alldata = pd.concat([alldata,timepoints], sort=False)
+                    alldata.append(timepoints)
                     
                     openapps[app] = {'open': False}
-            
-        if interaction == interactions.notification_seen:
-            timepoints = get_timestamps(curtime, precision=precision, row=row)
-            timepoints[columns.prep_record_type] = 'Notification Seen'
-            
-            alldata = pd.concat([alldata,timepoints], sort=False)
-            
-        if interaction == interactions.notification_interruption:
-            timepoints = get_timestamps(curtime, precision=precision, row=row)
-            timepoints[columns.prep_record_type] = 'Notification Interruption'
-            
-            alldata = pd.concat([alldata,timepoints], sort=False)
-            
-        if interaction == interactions.screen_non_interactive:
-            timepoints = get_timestamps(curtime, precision=precision, row=row)
-            timepoints[columns.prep_record_type] = 'Screen Non-interactive'
-            
-            alldata = pd.concat([alldata,timepoints], sort=False)
         
-        if interaction == interactions.screen_interactive:
-            timepoints = get_timestamps(curtime, precision=precision, row=row)
-            timepoints[columns.prep_record_type] = 'Screen Interactive'
-            
-            alldata = pd.concat([alldata,timepoints], sort=False)
 
+
+        if interaction in other_interactions.keys():
+            timepoints = get_timestamps(curtime, precision=precision, row=row)
+            timepoints[columns.prep_record_type] = other_interactions[interaction]
+            
+            alldata.append(timepoints)
+    print(sum(tot))
+    print(sum(tot)/len(tot))
+    alldata = pd.concat(alldata, axis = 0)
     if len(alldata)>0:
         alldata = alldata.sort_values(by=[columns.prep_datetime_start, columns.prep_datetime_end]).reset_index(drop=True)
         cols_to_select = list(set(cols).intersection(set(alldata.columns)))
@@ -307,10 +288,12 @@ def log_exceed_durations_minutes(row, threshold, outfile):
 
 def preprocess_dataframe(dataframe, precision=3600,sessioninterval = [5*60], logdir=None, logopts={}):
     dataframe = utils.backwards_compatibility(dataframe)
+    utils.logger("LOG: Extracting usage...",level=1)
     tmp = extract_usage(dataframe,precision=precision)
     if not isinstance(tmp,pd.DataFrame) or np.sum(tmp[columns.prep_duration_seconds]) == 0:
         return None
         utils.logger("WARNING: File %s does not seem to contain relevant data.  Skipping..."%filename)
+    utils.logger("LOG: checking overlap session...",level=1)
     data = check_overlap_add_sessions(tmp,session_def=sessioninterval)
     data = utils.add_warnings(data)
     non_timed = tmp[tmp[columns.prep_duration_seconds].isna()]

--- a/chroniclepy/chroniclepy/summarise_person.py
+++ b/chroniclepy/chroniclepy/summarise_person.py
@@ -79,7 +79,7 @@ def summarise_person(preprocessed,personID = None, quarterly=False, splitweek = 
         nighttime_dt = datetime.strptime(nighttime, "%H:%M")
     
         # daytime
-        daytime_df = preprocessed[(preprocessed.start_timestamp.dt.time > daytime_dt.time()) & (preprocessed.start_timestamp.dt.time < nighttime_dt.time())]
+        daytime_df = preprocessed[(preprocessed.app_start_timestamp.dt.time > daytime_dt.time()) & (preprocessed.app_start_timestamp.dt.time < nighttime_dt.time())]
         
         if len(daytime_df) > 0:
             data['daytime'] = summarise_modalities.summarise_daily(daytime_df.reset_index(drop=True),engagecols, datelist)
@@ -91,7 +91,7 @@ def summarise_person(preprocessed,personID = None, quarterly=False, splitweek = 
             utils.logger("WARNING: No daytime data for %s..."%personID,level=1)
 
         # nighttime
-        nighttime_df = preprocessed[(preprocessed.start_timestamp < nighttime_dt) | (preprocessed.start_timestamp > nighttime_dt)]
+        nighttime_df = preprocessed[(preprocessed.app_start_timestamp.dt.time < daytime_dt.time()) | (preprocessed.app_start_timestamp.dt.time > nighttime_dt.time())]
 
         if len(nighttime) > 0:
             data['nighttime'] = summarise_modalities.summarise_daily(nighttime_df.reset_index(drop=True),engagecols, datelist)


### PR DESCRIPTION
According to [this stack overflow response](https://stackoverflow.com/questions/36489576/why-does-concatenation-of-dataframes-get-exponentially-slower), concatenation becomes O(n^2) within a for loop because 

> pd.concat returns a new DataFrame. Space has to be allocated for the new DataFrame, and data from the old DataFrames have to be copied into the new DataFrame.

Instead, the response suggests creating a bunch of small dataframes and putting them in lists (O(1)), then doing a pd.concat at the very end (O(n)).

I tested this with a dataset that took over 3 days to run with the original code, with the new fix it takes 40 minutes to run. 

I don't think this will solve all of the problems of the pre-processor. When it's about 100k rows, it still takes quite a while to even grab the data and push the data. But hopefully this will allow the job to stop hanging for long periods of time. 😄 

I also condensed one part of the code (it was doing four if statements, I just turned it into a dictionary) and added some logs to see the overall performance in the preprocessing step.
